### PR TITLE
Ensure Twig iterability check works on PHP 7.2+

### DIFF
--- a/views/index.html.twig
+++ b/views/index.html.twig
@@ -76,7 +76,7 @@
                                 <th>Required by</th>
                                 <td>
                                     {% set package_dependencies = attribute(dependencies, name) %}
-                                    {% if package_dependencies|length %}
+                                    {% if package_dependencies is iterable %}
                                         <ul>
                                             {% for dependency in package_dependencies %}
                                                 <li><a href="#{{ dependency }}">{{ dependency }}</a></li>


### PR DESCRIPTION
Fixes template error on PHP 7.3: `Parameter must be an array or an object that implements Countable`
(Production is on 7.1)